### PR TITLE
feat: add inject subcommand for shell environment setup

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,11 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize]
     # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    paths:
+      - "bin/**/*.js"
+      - "lib/**/*.js"
 
 jobs:
   claude-review:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## 这个工具包做了什么？
 
-这个工具做一些微笑的工作，帮你节省时间去处理配置的工作。底层是在启动 claude 之前设定好 API Key 和 Base URL 环境变量参数。
+这个工具做一些微小的工作，帮你节省时间去处理配置的工作。底层是在启动 claude 之前设定好 API Key 和 Base URL 环境变量参数。
 
 对比其他教程让你配置文件，或者在启动时加长长的参数，使用本工具会节省你宝贵的时间精力。
 
@@ -26,13 +26,20 @@
 - 第二步，在你本地有 Nodejs 环境的前提下，运行 `npx kimicc` 安装并启动，或者使用 `npm install -g kimicc`；
 - 第三步，在安装后可使用 kimicc 直接启动，并在提示下输入 API Key。
 
-启动后会提示你输入 API Key，下次就无需再次设置。
+首次初始化会提示你输入 API Key，下次就无需再次设置。
+
+⚠️注意⚠️，
 
 ![screenshot](assets/screenshot.png)
 
 如何卸载： `npm uninstall kimicc`
 
 完全卸载 claude code：`npm uninstall @anthropic-ai/claude-code`
+
+### 附加命令功能
+
+- `kimicc reset` 重制配置。
+- `kimicc inject` 将配置写入 shell 配置中，后续可以用 claude 直接启动，无需再通过 kimicc。注意，可以用 `kimicc inject --reset` 删除写入的配置。
 
 ## 已知问题
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 首次初始化会提示你输入 API Key，下次就无需再次设置。
 
-⚠️注意⚠️，
+⚠️注意⚠️，启动时 Claude Code 会询问 API KEY，默认是 YES，此时要选 NO。
 
 ![screenshot](assets/screenshot.png)
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -117,7 +117,8 @@ function updateClaudeSettings() {
 }
 
 function detectShellType() {
-  const shell = process.env.SHELL || '';
+  // Check multiple sources for shell detection
+  const shell = process.env.SHELL || process.env.CMD || '';
   
   if (shell.includes('zsh')) return 'zsh';
   if (shell.includes('bash')) return 'bash';
@@ -157,8 +158,11 @@ function validateShellConfig(configFile) {
     if (fs.existsSync(configFile)) {
       fs.accessSync(configFile, fs.constants.W_OK);
     } else {
-      // Check if directory is writable
+      // Check if directory exists and is writable, create if needed
       const dir = path.dirname(configFile);
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true, mode: 0o755 });
+      }
       fs.accessSync(dir, fs.constants.W_OK);
     }
     return { valid: true };
@@ -240,13 +244,15 @@ async function injectEnvVariables(apiKey, shellType, force = false) {
   try {
     const baseUrl = 'https://api.moonshot.cn/anthropic';
     const timestamp = new Date().toISOString();
+    const markerStart = '# KimiCC Environment Variables - Added';
+    const markerEnd = '# End KimiCC Environment Variables';
     
     // Prepare new content
     const newContent = `
-# KimiCC Environment Variables - Added ${timestamp}
+${markerStart} ${timestamp}
 export ANTHROPIC_BASE_URL="${baseUrl}"
 export ANTHROPIC_API_KEY="${apiKey}"
-# End KimiCC Environment Variables
+${markerEnd}
 `;
     
     // Read existing content
@@ -255,17 +261,24 @@ export ANTHROPIC_API_KEY="${apiKey}"
       existingContent = fs.readFileSync(configFile, 'utf8');
     }
     
-    // Remove existing KimiCC variables if they exist
-    const cleanedContent = existingContent.replace(
-      /# KimiCC Environment Variables.*?# End KimiCC Environment Variables\n/s,
-      ''
-    );
+    // Remove existing KimiCC variables using safe string methods
+    let cleanedContent = existingContent;
+    const startMarkerIndex = cleanedContent.indexOf(markerStart);
+    const endMarkerIndex = cleanedContent.indexOf(markerEnd);
+    
+    if (startMarkerIndex !== -1 && endMarkerIndex !== -1 && endMarkerIndex > startMarkerIndex) {
+      const endMarkerLength = markerEnd.length;
+      const endIndex = endMarkerIndex + endMarkerLength;
+      cleanedContent = cleanedContent.slice(0, startMarkerIndex) + cleanedContent.slice(endIndex);
+    }
     
     // Append new variables
     const finalContent = cleanedContent.trimEnd() + newContent;
     
-    // Write updated config
-    fs.writeFileSync(configFile, finalContent);
+    // Write updated config with proper file locking to prevent race conditions
+    const tempFile = configFile + '.tmp';
+    fs.writeFileSync(tempFile, finalContent);
+    fs.renameSync(tempFile, configFile);
     
     console.log(`✅ Environment variables injected into ${configFile}`);
     if (backupFile) {
@@ -285,6 +298,88 @@ export ANTHROPIC_API_KEY="${apiKey}"
   }
 }
 
+async function removeEnvVariables(shellType, force = false) {
+  const configFile = getShellConfigFile(shellType);
+  
+  // Validate shell config
+  const validation = validateShellConfig(configFile);
+  if (!validation.valid) {
+    throw new Error(`Invalid shell configuration: ${validation.error}`);
+  }
+  
+  if (!fs.existsSync(configFile)) {
+    console.log(`ℹ️  Shell config file not found: ${configFile}`);
+    return false;
+  }
+  
+  // Check if KimiCC variables exist
+  const content = fs.readFileSync(configFile, 'utf8');
+  const markerStart = '# KimiCC Environment Variables - Added';
+  const markerEnd = '# End KimiCC Environment Variables';
+  
+  const startIndex = content.indexOf(markerStart);
+  const endIndex = content.indexOf(markerEnd);
+  
+  if (startIndex === -1 || endIndex === -1 || endIndex <= startIndex) {
+    console.log('ℹ️  No KimiCC environment variables found to remove.');
+    return false;
+  }
+  
+  if (!force) {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout
+    });
+    
+    return new Promise((resolve) => {
+      rl.question('Are you sure you want to remove KimiCC environment variables? (y/N): ', (answer) => {
+        rl.close();
+        if (answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes') {
+          proceedWithRemoval();
+          resolve(true);
+        } else {
+          console.log('Removal cancelled.');
+          resolve(false);
+        }
+      });
+    });
+  } else {
+    proceedWithRemoval();
+    return true;
+  }
+  
+  function proceedWithRemoval() {
+    // Backup original config
+    const backupFile = backupConfigFile(configFile);
+    
+    try {
+      // Remove the marked section
+      const endMarkerLength = markerEnd.length;
+      const endIndexWithMarker = endIndex + endMarkerLength;
+      const cleanedContent = content.slice(0, startIndex) + content.slice(endIndexWithMarker);
+      
+      // Write updated config with proper file locking
+      const tempFile = configFile + '.tmp';
+      fs.writeFileSync(tempFile, cleanedContent);
+      fs.renameSync(tempFile, configFile);
+      
+      console.log(`✅ KimiCC environment variables removed from ${configFile}`);
+      if (backupFile) {
+        console.log(`📋 Backup created at ${backupFile}`);
+      }
+      console.log(`\n💡 To apply changes, run: source ${configFile}`);
+      
+    } catch (error) {
+      // Restore backup on failure
+      if (backupFile && fs.existsSync(backupFile)) {
+        fs.copyFileSync(backupFile, configFile);
+        console.error('❌ Failed to remove variables, restored original config');
+      }
+      throw error;
+    }
+  }
+}
+
 module.exports = {
   checkClaudeInPath,
   installClaudeCode,
@@ -293,5 +388,6 @@ module.exports = {
   detectShellType,
   getShellConfigFile,
   validateShellConfig,
-  injectEnvVariables
+  injectEnvVariables,
+  removeEnvVariables
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -116,9 +116,182 @@ function updateClaudeSettings() {
   }
 }
 
+function detectShellType() {
+  const shell = process.env.SHELL || '';
+  
+  if (shell.includes('zsh')) return 'zsh';
+  if (shell.includes('bash')) return 'bash';
+  if (shell.includes('fish')) return 'fish';
+  
+  // Try to detect from process name
+  try {
+    const shellName = path.basename(shell);
+    if (shellName.includes('zsh')) return 'zsh';
+    if (shellName.includes('bash')) return 'bash';
+    if (shellName.includes('fish')) return 'fish';
+  } catch {
+    // fallback to bash as most common
+  }
+  
+  return 'bash';
+}
+
+function getShellConfigFile(shellType) {
+  const homeDir = os.homedir();
+  
+  switch (shellType) {
+    case 'zsh':
+      return path.join(homeDir, '.zshrc');
+    case 'bash':
+      return path.join(homeDir, '.bashrc');
+    case 'fish':
+      return path.join(homeDir, '.config', 'fish', 'config.fish');
+    default:
+      return path.join(homeDir, '.bashrc');
+  }
+}
+
+function validateShellConfig(configFile) {
+  try {
+    // Check if file exists and is writable
+    if (fs.existsSync(configFile)) {
+      fs.accessSync(configFile, fs.constants.W_OK);
+    } else {
+      // Check if directory is writable
+      const dir = path.dirname(configFile);
+      fs.accessSync(dir, fs.constants.W_OK);
+    }
+    return { valid: true };
+  } catch (error) {
+    return { valid: false, error: error.message };
+  }
+}
+
+function backupConfigFile(configFile) {
+  if (fs.existsSync(configFile)) {
+    const backupFile = `${configFile}.backup.${Date.now()}`;
+    fs.copyFileSync(configFile, backupFile);
+    return backupFile;
+  }
+  return null;
+}
+
+function checkExistingEnvVars(configFile) {
+  const envVars = {
+    ANTHROPIC_API_KEY: false,
+    ANTHROPIC_BASE_URL: false
+  };
+  
+  if (!fs.existsSync(configFile)) {
+    return envVars;
+  }
+  
+  try {
+    const content = fs.readFileSync(configFile, 'utf8');
+    
+    // Check for existing exports
+    Object.keys(envVars).forEach(key => {
+      const regex = new RegExp(`^\\s*export\\s+${key}=`, 'm');
+      envVars[key] = regex.test(content);
+    });
+    
+    return envVars;
+  } catch (error) {
+    console.warn(`Warning: Could not read config file: ${error.message}`);
+    return envVars;
+  }
+}
+
+async function injectEnvVariables(apiKey, shellType, force = false) {
+  const configFile = getShellConfigFile(shellType);
+  
+  // Validate shell config
+  const validation = validateShellConfig(configFile);
+  if (!validation.valid) {
+    throw new Error(`Invalid shell configuration: ${validation.error}`);
+  }
+  
+  // Check for existing variables
+  const existing = checkExistingEnvVars(configFile);
+  const hasExisting = Object.values(existing).some(v => v);
+  
+  if (hasExisting && !force) {
+    console.log('⚠️  Environment variables already exist in shell config:');
+    Object.entries(existing).forEach(([key, exists]) => {
+      if (exists) console.log(`   - ${key}`);
+    });
+    
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout
+    });
+    
+    return new Promise((resolve) => {
+      rl.question('Do you want to overwrite them? (y/N): ', (answer) => {
+        rl.close();
+        resolve(answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes');
+      });
+    });
+  }
+  
+  // Backup original config
+  const backupFile = backupConfigFile(configFile);
+  
+  try {
+    const baseUrl = 'https://api.moonshot.cn/anthropic';
+    const timestamp = new Date().toISOString();
+    
+    // Prepare new content
+    const newContent = `
+# KimiCC Environment Variables - Added ${timestamp}
+export ANTHROPIC_BASE_URL="${baseUrl}"
+export ANTHROPIC_API_KEY="${apiKey}"
+# End KimiCC Environment Variables
+`;
+    
+    // Read existing content
+    let existingContent = '';
+    if (fs.existsSync(configFile)) {
+      existingContent = fs.readFileSync(configFile, 'utf8');
+    }
+    
+    // Remove existing KimiCC variables if they exist
+    const cleanedContent = existingContent.replace(
+      /# KimiCC Environment Variables.*?# End KimiCC Environment Variables\n/s,
+      ''
+    );
+    
+    // Append new variables
+    const finalContent = cleanedContent.trimEnd() + newContent;
+    
+    // Write updated config
+    fs.writeFileSync(configFile, finalContent);
+    
+    console.log(`✅ Environment variables injected into ${configFile}`);
+    if (backupFile) {
+      console.log(`📋 Backup created at ${backupFile}`);
+    }
+    console.log(`\n💡 To apply changes, run: source ${configFile}`);
+    
+    return true;
+    
+  } catch (error) {
+    // Restore backup on failure
+    if (backupFile && fs.existsSync(backupFile)) {
+      fs.copyFileSync(backupFile, configFile);
+      console.error('❌ Failed to inject variables, restored original config');
+    }
+    throw error;
+  }
+}
+
 module.exports = {
   checkClaudeInPath,
   installClaudeCode,
   getApiKey,
-  updateClaudeSettings
+  updateClaudeSettings,
+  detectShellType,
+  getShellConfigFile,
+  validateShellConfig,
+  injectEnvVariables
 };

--- a/plan.v2.md
+++ b/plan.v2.md
@@ -1,0 +1,34 @@
+# KimiCC v2 Plan
+
+## feature#1 reset subcommand
+
+添加 reset 子命令删除 .kimicc.json 配置文件。
+
+DONE: PR#3
+
+## feature#2 inject environment to shell config
+
+添加 inject 子命令，实现以下能力：
+
+假如仅使用单一版本 kimi k2 版本，则可以设置到 shell（如根据情况写入 export env key 到 .bashrc 或 .zshrc）。这样 claude code 默认启动就采用设定的 ANTHROPIC_API_KEY 与 ANTHROPIC_BASE_URL，方便其他程序调用。
+
+zsh用户：
+echo 'export ANTHROPIC_BASE_URL="https://api.moonshot.cn/anthropic/"' >> ~/.zshrc
+echo 'export ANTHROPIC_API_KEY="你的实际API密钥"' >> ~/.zshrc
+source ~/.zshrc
+
+bash用户：
+echo 'export ANTHROPIC_BASE_URL="https://api.moonshot.cn/anthropic/"' >> ~/.bashrc
+echo 'export ANTHROPIC_API_KEY="你的实际API密钥"' >> ~/.bashrc
+source ~/.bashrc
+
+## feature#3 multi profiles
+
+为了可以使用多个服务供应商并发多个 kimicc 实例，可以在 .kimicc.json 配置文件中添加 `{'profiles':{ $slug: { url: $url, key: $apikey }, ... }}` 的配置，并在启动时选择不同 profile 设定。
+
+提供子命令
+- profile list ：列出所有 profile。
+- profile add --slug $slug $url $apikey ：添加新的profile，自动将 url 中的 hostname，如 123.example.com => examplecom 作为 slug，也可指定 slug。
+- profile del $slug ：删除某个 profile，需要用户输入作为确认。
+
+启动时添加 --profile 选择不同的 profile，选择后读取配置中的 url 与 key 设定到 claude 启动的进程环境变量中。


### PR DESCRIPTION
Add inject subcommand to automatically set ANTHROPIC_API_KEY and ANTHROPIC_BASE_URL in shell config files. Supports bash/zsh/fish with safety features including backups and conflict detection.